### PR TITLE
Tweak a bit the french translation

### DIFF
--- a/fr.lproj/SwipeSelectionPro.strings
+++ b/fr.lproj/SwipeSelectionPro.strings
@@ -21,9 +21,9 @@
 	SENSITIVITY = "Sensibilité";
 	SWIPE_SENSITIVITY = "À quelle sensibilité doit être SwipeSelection ?";
 
-	NORMAL = "Normal";
-	REDUCED = "Réduit";
-	INSENSITIVE = "Peu sensible";
+	NORMAL = "Normale";
+	REDUCED = "Limitée";
+	INSENSITIVE = "Faible";
 
 
 	SWIPE_SPEED = "Vitesse du swipe";
@@ -37,5 +37,5 @@
 
 
 	THREE_FINGER_SWIPE = "Swipe avec 3 doigts";
-	THREE_FINGER_SWIPE_FOOTER = "Utiliser trois doigts pour aller au début ou à la fin du texte. (Utiliser de préférence sur iPad)";
+	THREE_FINGER_SWIPE_FOOTER = "Utiliser trois doigts pour aller au début ou à la fin du texte. (Optimisé pour iPad)";
 }


### PR DESCRIPTION
La traduction 'Peu sensible' n'est pas clairement inférieure à 'Réduit'. La nouvelle traduction propose un palier plus clair.
Concernant la parenthèse, la nouvelle formulation remplace le sous entendu que la version iPhone de la feature est inférieure par le sous entendu que la version iPad est supérieure. Petit truc de marketing 😉
